### PR TITLE
Implements default zooming and corrects read legend

### DIFF
--- a/db_manager/db_app/static/js/node_handling/reads_coloring.js
+++ b/db_manager/db_app/static/js/node_handling/reads_coloring.js
@@ -135,9 +135,9 @@ const palette = (scale, x, readMode) => { // x is the number of colors to the
       color_element = scale(i / x).hex()
       $('#scaleLegend').append('<span class="grad-step" style="background-color:' + color_element + '; width:' + style_width + '%"></span>')
     }
-    $('#scaleLegend').append('<div class="header_taxa" id="min">0</div>')
+    $('#scaleLegend').append('<div class="header_taxa" id="min">0.1</div>')
     $('#scaleLegend').append('<div class="header_taxa" id="med">0.05</div>')
-    $('#scaleLegend').append('<div class="header_taxa" id="max">0.1</div>')
+    $('#scaleLegend').append('<div class="header_taxa" id="max">0</div>')
     document.getElementById('distance_label').style.display = 'block' // show label
   } else { // here enters for coloring the reads
     $('#readLegend').empty()

--- a/db_manager/db_app/static/js/visualization_functions.js
+++ b/db_manager/db_app/static/js/visualization_functions.js
@@ -157,6 +157,8 @@ const onLoad = () => {
     // computational intensive for old computers
     renderer.pause()
 
+    defaultZooming(layout,renderer)
+
     // used to center on the node with more links
     // this is used to skip if it is a re-run button execution
     if (storeMasterNode.length > 0) {

--- a/db_manager/db_app/static/js/vivagraph_control/zooming_control.js
+++ b/db_manager/db_app/static/js/vivagraph_control/zooming_control.js
@@ -1,0 +1,22 @@
+// Final bit: most likely graph will take more space than available
+// screen. Let's zoom out to fit it into the view:
+
+const defaultZooming = (layout,renderer) => {
+  var graphRect = layout.getGraphRect()
+  var graphSize = Math.min(graphRect.x2 - graphRect.x1, graphRect.y2 - graphRect.y1)
+  var screenSize = Math.min(document.body.clientWidth, document.body.clientHeight)
+  var desiredScale = screenSize / graphSize
+
+  const zoomOut = (desiredScale, currentScale) => {
+    // zoom API in vivagraph 0.5.x is silly. There is no way to pass transform
+    // directly. Maybe it will be fixed in future, for now this is the best I could do:
+    if (desiredScale < currentScale) {
+      currentScale = renderer.zoomOut();
+      setTimeout(function () {
+        zoomOut(desiredScale, currentScale);
+      }, 16);
+    }
+  }
+
+  zoomOut(desiredScale, 1)
+}

--- a/db_manager/db_app/templates/index.html
+++ b/db_manager/db_app/templates/index.html
@@ -44,6 +44,7 @@
       <!--input files handler script-->
       <script language="javascript" type="text/javascript" src="{{ url_for('static', filename='js/input_file_handling/input_file_handler.js') }}"></script>
       <script language="javascript" type="text/javascript" src="{{ url_for('static', filename='js/input_file_handling/assembly_file_handler.js') }}"></script>
+      <script language="javascript" type="text/javascript" src="{{ url_for('static', filename='js/vivagraph_control/zooming_control.js') }}"></script>
 
     </head>
     


### PR DESCRIPTION
First, this PR doesn't solve #15  but makes a correction regarding this read legend.
Also, default zooming now zoom's out after rendering the graph in order to have the full dispersion of nodes (whether they are very close or very apart from each other).