### PR TITLE
Auto complete handling

### DIFF
--- a/db_manager/db_app/static/css/visualization_functions.css
+++ b/db_manager/db_app/static/css/visualization_functions.css
@@ -45,7 +45,7 @@
 }
 /*resize search box for gi*/
 #formValueId{
-  width: 150px;
+  width: 200px;
 }
 
 /*set glyphicon size*/

--- a/db_manager/db_app/static/css/visualization_functions.css
+++ b/db_manager/db_app/static/css/visualization_functions.css
@@ -127,7 +127,7 @@
 
 #slider_input_min{
   width: 50%;
-  height: 10%;
+  height: 20px;
 }
 
 /*input max value*/
@@ -137,7 +137,7 @@
 
 #slider_input_max{
   width: 50%;
-  height: 12px;
+  height: 20px;
 }
 
 /*slider related costumization*/

--- a/db_manager/db_app/static/js/visualization_functions.js
+++ b/db_manager/db_app/static/js/visualization_functions.js
@@ -376,13 +376,13 @@ const onLoad = () => {
 
     // Form and button for search box
     let changed_nodes = []
-    $('#submitButton').click(function (event) {
-      const query = $('#formValueId').val()
+    $("#submitButton").click(function (event) {
+      const query = $("#formValueId").val().replace(".", "_")
       //console.log('search query: ' + query)
       event.preventDefault()
       g.forEachNode( (node) => {
         const nodeUI = graphics.getNodeUI(node.id)
-        const sequence = node.data.sequence.split('>')[3].split('<')[0]
+        const sequence = node.data.sequence.split(">")[3].split("<")[0]
         // console.log(sequence)
         //nodeUI = graphics.getNodeUI(node.id)
         const x = nodeUI.position.x,
@@ -394,8 +394,8 @@ const onLoad = () => {
       })
     })
     // Button to clear the selected nodes by form
-    $('#clearButton').click(function (event) {
-      document.getElementById('formValueId').value = ''
+    $("#clearButton").click(function (event) {
+      document.getElementById("formValueId").value = ""
     })
 
     //* ***********************//
@@ -405,11 +405,11 @@ const onLoad = () => {
     // Form search box utils
 
     // then applying autocomplete function
-    $( () => {
-      $('#formValueId').autocomplete({
-        source: list_gi
-      })
-    })
+    // $( () => {
+    //   $('#formValueId').autocomplete({
+    //     source: list_gi
+    //   })
+    // })
 
     //* ******************//
     //* ***Taxa Filter****//

--- a/db_manager/db_app/templates/index.html
+++ b/db_manager/db_app/templates/index.html
@@ -463,8 +463,10 @@
                         data-onstyle="success" data-offstyle="default" 
                         data-on="Node mode on" data-off="Node mode off" 
                         title="Enable/Disable node selection mode" id="toggle-event">
-                <div class="form-group">
-                  <input id="formValueId" type="text" class="form-control" placeholder="Enter an accession"/>
+                <div class="form-group" data-toggle="tooltip"
+                     title="e.g 'NZ_CP012658.1'">
+                  <input id="formValueId" type="text" class="form-control"
+                         placeholder="Search an accession number"/>
                 </div>
                 <div class="btn-group">
                   <button id="submitButton" type="submit" data-toggle="tooltip" 


### PR DESCRIPTION
This fixes several issues with boxes for length and accession number searches and removes auto complete function for accession number searches since it stored more than 7k entries which makes it too slow and useless. At least without the auto-complete for now users that know an accession number of interest can quickly search it. It also accepts accessions like: `NZ_CP012658.1` and `NZ_CP012658_1`