### PR TITLE
added two new apis to download data from pATLAS database.

### DIFF
--- a/patlas/db_manager/db_app/api.py
+++ b/patlas/db_manager/db_app/api.py
@@ -17,7 +17,8 @@ except ImportError:
         from patlas.db_manager.db_app import app
         from patlas.db_manager.db_app.resources import GetSpecies, GetAccession, \
             GetResistances, GetPlasmidFinder, GetAccessionRes, \
-            GetAccessionPF, GetPlasmidName, GetAccessionVir, GetVirulence, GetAccessionTaxa
+            GetAccessionPF, GetPlasmidName, GetAccessionVir, GetVirulence, \
+            GetAccessionTaxa
 
 ## start api
 api = Api(app)

--- a/patlas/db_manager/db_app/resources.py
+++ b/patlas/db_manager/db_app/resources.py
@@ -188,12 +188,11 @@ class GetPlasmidName(Resource):
     def get(self):
         # Put req_parser inside get function. Only this way it parses the request.
         args = req_parser.parse_args()
-        print(args.plasmid_name)
         # This queries if input plasmid name is present in db
         # func.lower() function from sqalchemy allows the user to make case insensitive searches
         records = db.session.query(Plasmid).filter(func.lower(
-            Plasmid.json_entry["plasmid_name"].astext) == func.lower(args.plasmid_name)
-        ).first()
+            Plasmid.json_entry["plasmid_name"].astext) == func.lower(
+            args.plasmid_name)).first()
         # contains method allows us to query in array that is converted to a
         # string
         return records


### PR DESCRIPTION
this pr intends to add an api to download metadata associated to accession number queries. Although plasmid atlas doesn't use this API currently, other users may access it by doing:

```
http://www.patlas.site/api/sendmetadata/?accession=<list_of_accessions>
```

in the browser URL.